### PR TITLE
Revert "Bump pywin32 from 227 to 301"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,7 @@ pyparsing==3.0.7; python_version >= "3.6"
 pytest==6.2.5; python_version >= "3.6"
 python-dateutil==2.8.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 pytz==2022.1
-pywin32==301; sys_platform == "win32" and python_version >= "3.6"
+pywin32==227; sys_platform == "win32" and python_version >= "3.6"
 pyyaml==6.0; python_version >= "3.6"
 requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 responses==0.17.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"


### PR DESCRIPTION
Causes a conflict with the latest python docker lib which was caught by poetry. Reverting this to keep the dev deps in sync.


```
> updater | <job_371795759>   Because cdn-proxy depends on docker (5.0.3) which depends on pywin32 (227), pywin32 is required.
> updater | <job_371795759>   So, because cdn-proxy depends on pywin32 (301), version solving failed.
```